### PR TITLE
Add proxy tool to customise the routing of public API requests

### DIFF
--- a/node-proxy/public-api-proxy.js
+++ b/node-proxy/public-api-proxy.js
@@ -1,0 +1,60 @@
+const http = require("http");
+const https = require("https");
+const url = require("url");
+
+// Maps request to first matching mapping.
+const pathMappings = [
+  {
+    pattern: /^\/v2\//,
+    baseAddress: "http://localhost:5086",
+  },
+  {
+    pattern: /./,
+    baseAddress: "https://tran-api.signin.education.gov.uk",
+  }
+];
+
+function resolveTargetUri(path) {
+  for (let mapping of pathMappings) {
+    if (mapping.pattern.test(path)) {
+      return `${mapping.baseAddress}${path}`;
+    }
+  }
+  throw new Error(`Cannot resolve mapping for path '${path}'.`);
+}
+
+const server = http.createServer(handler);
+const httpListenOnPort = 3011;
+server.listen(httpListenOnPort, () => {console.log(`Proxy listening on: ${httpListenOnPort}`)});
+
+function handler(req, res) {
+  const originalRequestUrl = req.url;
+  const targetUri = resolveTargetUri(url.parse(originalRequestUrl).path);
+  const { protocol, hostname, port, path } = url.parse(targetUri);
+
+  const options = {
+    hostname,
+    port,
+    path,
+    method: req.method,
+    headers: req.headers,
+    // minVersion: "TLSv1.3" // Force TLS 1.3
+  };
+
+  console.log(`Requesting: ${originalRequestUrl}...`);
+
+  const requestHandler = protocol === "https" ? https : http;
+  const proxyReq = requestHandler.request(options, (proxyRes) => {
+    const dt = (new Date()).toJSON().slice(0,19).replace("T", ":")
+    console.log(`${dt} ${proxyRes.req.method} ${originalRequestUrl}\n  --> ${proxyRes.statusCode} ${proxyRes.req.protocol}//${proxyRes.req.host}${proxyRes.req.path}`);
+    res.writeHead(proxyRes.statusCode, proxyRes.headers);
+    proxyRes.pipe(res); // Plain HTTP back
+  });
+
+  req.pipe(proxyReq);
+  proxyReq.on("error", (err) => {
+    console.error(err);
+    res.writeHead(500);
+    res.end("Proxy error: " + err.message);
+  });
+}


### PR DESCRIPTION
This tool enables developers to specify how specific public API paths are handled.

For example; all `/v2/*` requests could be handled by a locally running instance of the .NET version of the public API whilst all other requests could be handled by a locally running instance of the Node.js version of the public API.