### PR TITLE
Add script to generate bearer tokens for use with the Public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ HttpClientHandler httpClientHandler = new HttpClientHandler()
 
 HttpClient client = new HttpClient(httpClientHandler);
 ```
+
+## Script: public-api/GenerateAuthorizationToken.ps1
+
+This script generates a bearer token for use with the DfE Sign-in Public API which takes the `clientId` and `apiSecret` of a service.
+
+Usage example:
+
+```pwsh
+./public-api/GenerateAuthorizationToken.ps1 -clientId "ExampleClient" -apiSecret "example-api-secret"
+```

--- a/public-api/GenerateAuthorizationToken.ps1
+++ b/public-api/GenerateAuthorizationToken.ps1
@@ -1,0 +1,38 @@
+param (
+    [string]$clientId,
+    [string]$apiSecret,
+    [string]$audience = "signin.education.gov.uk"
+)
+
+function Normalize-HmacSha256Key {
+    param (
+        [byte[]]$keyBytes
+    )
+
+    if ($keyBytes.Length -lt 32) {
+        $paddedKey = New-Object byte[] 32
+        [Array]::Copy($keyBytes, 0, $paddedKey, 0, $keyBytes.Length)
+        return $paddedKey
+    }
+
+    return $keyBytes
+}
+
+function ConvertTo-Base64Url {
+    param ([byte[]]$bytes)
+    $base64 = [System.Convert]::ToBase64String($bytes)
+    $base64Url = $base64.TrimEnd('=') -replace '\+', '-' -replace '/', '_'
+    return $base64Url
+}
+
+$headerBytes = [System.Text.Encoding]::UTF8.GetBytes('{"alg":"HS256","typ":"JWT"}')
+$header = ConvertTo-Base64Url $headerBytes
+$bodyBytes = [System.Text.Encoding]::UTF8.GetBytes('{"iss":"' + $clientId + '","aud":"' + $audience + '"}')
+$body = ConvertTo-Base64Url $bodyBytes
+
+$hmac = New-Object System.Security.Cryptography.HMACSHA256
+$hmac.Key = Normalize-HmacSha256Key ([Text.Encoding]::UTF8.GetBytes($apiSecret))
+$signatureBytes = $hmac.ComputeHash([System.Text.Encoding]::UTF8.GetBytes("$header.$body"))
+$sig = ConvertTo-Base64Url $signatureBytes
+
+Write-Output "$header.$body.$sig"


### PR DESCRIPTION
Adds a script to facilitate developers when testing the Public API.

Refer to the updated `README.md` file for details on use.