### PR TITLE
Fix construction of cmdlets path

### DIFF
--- a/cmdlets/Show-DsiTools.ps1
+++ b/cmdlets/Show-DsiTools.ps1
@@ -21,7 +21,7 @@ function Show-DsiTools {
         }) -join ', '
     }
 
-    $subFolders = Get-ChildItem -Path ./cmdlets -Directory
+    $subFolders = Get-ChildItem -Path "$PSScriptRoot" -Directory
     $commands = Get-Command -Module DsiTools
     $subFolderMap = @{}
 


### PR DESCRIPTION
The `Show-DsiTools` cmdlet was not working when ran outside of the 'dsi-tools' repository.